### PR TITLE
Issue #CIVIC-1552: Fixes to make this module work OOTB

### DIFF
--- a/dkan_acquia_search_solr.info
+++ b/dkan_acquia_search_solr.info
@@ -2,6 +2,7 @@ name = DKAN Search - Solr
 description = Solr Search Settings for Local and Acquia Environments.
 core = 7.x
 package = DKAN
+dependencies[] = acquia_agent
 dependencies[] = search_api_solr
 dependencies[] = search_api_acquia
 features[features_api][] = api:2

--- a/dkan_acquia_search_solr.module
+++ b/dkan_acquia_search_solr.module
@@ -6,12 +6,20 @@
 
 include_once 'dkan_acquia_search_solr.features.inc';
 
+/*
+ * Implements hook_environment_switch.
+ */
+function dkan_acquia_search_solr_environment_switch($target_env, $source_env) {
+  features_revert_module('dkan_dataset_groups');
+  features_revert_module('dkan_sitewide_search_db');
+  features_revert_module('dkan_data_story');
+  features_revert_module('dkan_acquia_search_solr');
+}
 
 /**
  * Implements hook_default_search_api_index_alter().
  */
 function dkan_acquia_search_solr_default_search_api_index_alter(array &$defaults) {
-
   // List of the possible search api indexes.
   $index_list = array(
     "stories_index",
@@ -32,9 +40,10 @@ function dkan_acquia_search_solr_default_search_api_index_alter(array &$defaults
   }
 }
 
+/**
+ * Implements hook_default_search_api_server_alter().
+ */
 function dkan_acquia_search_solr_default_search_api_server_alter(array &$defaults) {
-
-
   // List of the possible search api indexes.
   $server_list = array(
     "groups_server",
@@ -55,9 +64,52 @@ function dkan_acquia_search_solr_default_search_api_server_alter(array &$default
   if (!$server_override = variable_get('dkan_acquia_search_solr_override', false)) {
     // No override is set so enable the acquia server.
     $defaults["dkan_acquia_solr"]->enabled = true;
+    $defaults["dkan_acquia_solr"]->options = _reset_acquia_search_from_subscription(
+      $defaults['dkan_acquia_solr']->options
+    );
+    // dkan_acquia_search_solr_set_acquia_search_from_subscription($defaults['dkan_acquia_solr']);
   }
   else {
     $defaults[$server_override]->enabled = true;
   }
+}
 
+function _reset_acquia_search_from_subscription($options) {
+    // Modify connection details live on every connect so we do not need to
+    // resave the server details if we make modifications in settings.php.
+    $identifier = acquia_agent_settings('acquia_identifier');
+    $subscription = acquia_agent_settings('acquia_subscription_data');
+
+    // Get our override if we have one. Otherwise use the default.
+    $search_host = variable_get('acquia_search_host', 'search.acquia.com');
+    if (!empty($subscription['heartbeat_data']['search_service_colony'])) {
+      $search_host = $subscription['heartbeat_data']['search_service_colony'];
+    }
+
+    // Get our solr path
+    $search_path = variable_get('acquia_search_path', '/solr/' . $identifier);
+
+    $options['host'] = $search_host;
+    $options['path'] = $search_path;
+
+    // Unset derived key so search_api_acquia sets this instead.
+    if (isset($options['derived_key'])) {
+      unset($options['derived_key']);
+    }
+    
+    // Remove stupid overrides from features export. :facepalm:.
+    if (isset($options['acquia_override_subscription'])) {
+      $unset = array(
+        'acquia_override_selector',
+        'acquia_override_subscription_id',
+        'acquia_override_subscription_key',
+        'acquia_override_subscription_corename',
+      );
+      foreach ($unset as $k) {
+        if (isset($options['acquia_override_subscription'][$k])) {
+          unset($options['acquia_override_subscription'][$k]);
+        }
+      }
+    }
+    return $options;
 }


### PR DESCRIPTION
# CIVIC 1552
- Implements environment switch to revert all servers and indexes
- Alters acquia server grabbing the host and path from the subscription data (instead of the feature)
- Alters acquia server unsetting derived key so it's set by search_api_acquia
