### PR TITLE
Update dkan_acquia_search_solr.module

### DIFF
--- a/dkan_acquia_search_solr.module
+++ b/dkan_acquia_search_solr.module
@@ -4,8 +4,6 @@
  * Code for the HHS Search feature.
  */
 
-include_once 'dkan_acquia_search_solr.features.inc';
-
 /**
  * Queries the search_api_server for dkan_acquia_solr.
  */


### PR DESCRIPTION
Fixes:

```
include_once(dkan_acquia_search_solr.features.inc): failed to open stream: No such file or directory dkan_acquia_search_solr.module:7                                  [warning]
include_once(): Failed opening 'dkan_acquia_search_solr.features.inc' for inclusion (include_path='.:/usr/local/php5.6/lib/php') dkan_acquia_search_solr.module:7      [warning]
The following views were using the index Stories Index: stories. You should disable or delete them.                                                                    [warning]
'all' cache was cleared.       
```
